### PR TITLE
execution options.

### DIFF
--- a/PoweredSoft.DynamicQuery.Core/IInterceptQueryExecutionOptions.cs
+++ b/PoweredSoft.DynamicQuery.Core/IInterceptQueryExecutionOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PoweredSoft.DynamicQuery.Core
+{
+    public interface IQueryExecutionOptionsInterceptor : IQueryInterceptor
+    {
+        IQueryExecutionOptions InterceptQueryExecutionOptions(IQueryable queryable, IQueryExecutionOptions current);
+    }
+}

--- a/PoweredSoft.DynamicQuery.Core/IQueryExecutionOptions.cs
+++ b/PoweredSoft.DynamicQuery.Core/IQueryExecutionOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace PoweredSoft.DynamicQuery.Core
+{
+    public interface IQueryExecutionOptions
+    {
+        bool GroupByInMemory { get; set; }
+        bool GroupByInMemoryNullCheck { get; set; }
+    }
+}

--- a/PoweredSoft.DynamicQuery.Core/IQueryHandler.cs
+++ b/PoweredSoft.DynamicQuery.Core/IQueryHandler.cs
@@ -15,11 +15,15 @@ namespace PoweredSoft.DynamicQuery.Core
     {
         IQueryExecutionResult<TSource> Execute<TSource>(IQueryable<TSource> queryable, IQueryCriteria criteria);
         IQueryExecutionResult<TRecord> Execute<TSource, TRecord>(IQueryable<TSource> queryable, IQueryCriteria criteria);
+        IQueryExecutionResult<TSource> Execute<TSource>(IQueryable<TSource> queryable, IQueryCriteria criteria, IQueryExecutionOptions options);
+        IQueryExecutionResult<TRecord> Execute<TSource, TRecord>(IQueryable<TSource> queryable, IQueryCriteria criteria, IQueryExecutionOptions options);
     }
 
     public interface IQueryHandlerAsync : IInterceptableQueryHandler
     {
-        Task<IQueryExecutionResult<TSource>> ExecuteAsync<TSource>(IQueryable<TSource> queryable, IQueryCriteria criteria, CancellationToken cancellationToken = default(CancellationToken));
-        Task<IQueryExecutionResult<TRecord>> ExecuteAsync<TSource, TRecord>(IQueryable<TSource> queryable, IQueryCriteria criteria, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IQueryExecutionResult<TSource>> ExecuteAsync<TSource>(IQueryable<TSource> queryable, IQueryCriteria criteria, CancellationToken cancellationToken = default);
+        Task<IQueryExecutionResult<TRecord>> ExecuteAsync<TSource, TRecord>(IQueryable<TSource> queryable, IQueryCriteria criteria, CancellationToken cancellationToken = default);
+        Task<IQueryExecutionResult<TSource>> ExecuteAsync<TSource>(IQueryable<TSource> queryable, IQueryCriteria criteria, IQueryExecutionOptions options, CancellationToken cancellationToken = default);
+        Task<IQueryExecutionResult<TRecord>> ExecuteAsync<TSource, TRecord>(IQueryable<TSource> queryable, IQueryCriteria criteria, IQueryExecutionOptions options, CancellationToken cancellationToken = default);
     }
 }

--- a/PoweredSoft.DynamicQuery.Core/QueryExecutionOptions.cs
+++ b/PoweredSoft.DynamicQuery.Core/QueryExecutionOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace PoweredSoft.DynamicQuery.Core
+{
+    public class QueryExecutionOptions : IQueryExecutionOptions
+    {
+        public bool GroupByInMemory { get; set; } = false;
+        public bool GroupByInMemoryNullCheck { get; set; } = false;
+    }
+}

--- a/PoweredSoft.DynamicQuery.Test/AggregateInterceptorTests.cs
+++ b/PoweredSoft.DynamicQuery.Test/AggregateInterceptorTests.cs
@@ -1,4 +1,5 @@
-﻿using PoweredSoft.DynamicQuery.Core;
+﻿using Microsoft.EntityFrameworkCore;
+using PoweredSoft.DynamicQuery.Core;
 using PoweredSoft.DynamicQuery.Test.Mock;
 using System;
 using System.Collections.Generic;
@@ -14,7 +15,7 @@ namespace PoweredSoft.DynamicQuery.Test
         {
             public IAggregate InterceptAggregate(IAggregate aggregate) => new Aggregate
             {
-                Path = "Item.Price",
+                Path = "Price",
                 Type = AggregateType.Avg
             };
         }
@@ -24,10 +25,12 @@ namespace PoweredSoft.DynamicQuery.Test
         {
             MockContextFactory.SeedAndTestContextFor("AggregatorInterceptorTests_Simple", TestSeeders.SimpleSeedScenario, ctx =>
             {
-                var expected = ctx.OrderItems.GroupBy(t => true).Select(t => new
-                {
-                    PriceAtTheTime = t.Average(t2 => t2.Item.Price)
-                }).First();
+                var expected = ctx.Items
+                    .GroupBy(t => true)
+                    .Select(t => new
+                    {
+                        PriceAtTheTime = t.Average(t2 => t2.Price)
+                    }).First();
 
                 var criteria = new QueryCriteria();
                 criteria.Aggregates.Add(new Aggregate
@@ -37,7 +40,7 @@ namespace PoweredSoft.DynamicQuery.Test
                 });
                 var queryHandler = new QueryHandler();
                 queryHandler.AddInterceptor(new MockAggregateInterceptor());
-                var result = queryHandler.Execute(ctx.OrderItems, criteria);
+                var result = queryHandler.Execute(ctx.Items, criteria);
                 Assert.Equal(expected.PriceAtTheTime, result.Aggregates.First().Value);
             });
         }

--- a/PoweredSoft.DynamicQuery.Test/AsyncTests.cs
+++ b/PoweredSoft.DynamicQuery.Test/AsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using PoweredSoft.Data;
+﻿using Microsoft.EntityFrameworkCore;
+using PoweredSoft.Data;
 using PoweredSoft.Data.EntityFrameworkCore;
 using PoweredSoft.DynamicQuery.Core;
 using PoweredSoft.DynamicQuery.Extensions;
@@ -9,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using static PoweredSoft.DynamicQuery.Test.GroupInterceptorTests;
 
 namespace PoweredSoft.DynamicQuery.Test
 {
@@ -65,7 +67,11 @@ namespace PoweredSoft.DynamicQuery.Test
                 };
                 var asyncService = new AsyncQueryableService(new[] { new AsyncQueryableHandlerService() });
                 var queryHandler = new QueryHandlerAsync(asyncService);
-                var result = await queryHandler.ExecuteAsync(ctx.OrderItems, criteria);
+                var result = await queryHandler.ExecuteAsync(ctx.OrderItems.Include(t => t.Order.Customer), criteria, new QueryExecutionOptions
+                {
+                    GroupByInMemory = true
+                });
+
                 var groups = result.GroupedResult().Groups;
 
                 // validate group and aggregates of groups.
@@ -163,6 +169,68 @@ namespace PoweredSoft.DynamicQuery.Test
                 var queryHandler = new QueryHandlerAsync(asyncService);
                 var result = await queryHandler.ExecuteAsync(ctx.OrderItems, criteria);
                 Assert.Equal(resultShouldMatch, result.Data);
+            });
+        }
+
+        [Fact]
+        public void WithGroupingInterceptorOptions()
+        {
+            MockContextFactory.SeedAndTestContextFor("AsyncTests_WithGroupingInterceptorOptions", TestSeeders.SimpleSeedScenario, async ctx =>
+            {
+                var shouldResults = ctx.OrderItems
+                    .GroupBy(t => t.Order.CustomerId)
+                    .Select(t => new
+                    {
+                        GroupValue = t.Key,
+                        Count = t.Count(),
+                        ItemQuantityAverage = t.Average(t2 => t2.Quantity),
+                        ItemQuantitySum = t.Sum(t2 => t2.Quantity),
+                        AvgOfPrice = t.Average(t2 => t2.PriceAtTheTime)
+                    })
+                    .ToList();
+
+                // query handler that is empty should be the same as running to list.
+                var criteria = new QueryCriteria()
+                {
+                    Groups = new List<IGroup>
+                    {
+                        new Group { Path = "Order.CustomerId" }
+                    },
+                    Aggregates = new List<Core.IAggregate>
+                    {
+                        new Aggregate { Type = AggregateType.Count },
+                        new Aggregate { Type = AggregateType.Avg, Path = "Quantity" },
+                        new Aggregate { Type = AggregateType.Sum, Path = "Quantity" },
+                        new Aggregate { Type = AggregateType.Avg, Path = "PriceAtTheTime"}
+                    }
+                };
+                var asyncService = new AsyncQueryableService(new[] { new AsyncQueryableHandlerService() });
+                var queryHandler = new QueryHandlerAsync(asyncService);
+                queryHandler.AddInterceptor(new MockQueryExecutionOptionsInterceptor());
+                var result = await queryHandler.ExecuteAsync(ctx.OrderItems.Include(t => t.Order.Customer), criteria);
+
+                var groups = result.GroupedResult().Groups;
+
+                // validate group and aggregates of groups.
+                Assert.Equal(groups.Count, shouldResults.Count);
+                Assert.All(groups, g =>
+                {
+                    var index = groups.IndexOf(g);
+                    var shouldResult = shouldResults[index];
+
+                    // validate the group value.
+                    Assert.Equal(g.GroupValue, shouldResult.GroupValue);
+
+                    // validate the group aggregates.
+                    var aggCount = g.Aggregates.First(t => t.Type == AggregateType.Count);
+                    var aggItemQuantityAverage = g.Aggregates.First(t => t.Type == AggregateType.Avg && t.Path == "Quantity");
+                    var aggItemQuantitySum = g.Aggregates.First(t => t.Type == AggregateType.Sum && t.Path == "Quantity");
+                    var aggAvgOfPrice = g.Aggregates.First(t => t.Type == AggregateType.Avg && t.Path == "PriceAtTheTime");
+                    Assert.Equal(shouldResult.Count, aggCount.Value);
+                    Assert.Equal(shouldResult.ItemQuantityAverage, aggItemQuantityAverage.Value);
+                    Assert.Equal(shouldResult.ItemQuantitySum, aggItemQuantitySum.Value);
+                    Assert.Equal(shouldResult.AvgOfPrice, aggAvgOfPrice.Value);
+                });
             });
         }
     }

--- a/PoweredSoft.DynamicQuery.Test/Mock/MockContextFactory.cs
+++ b/PoweredSoft.DynamicQuery.Test/Mock/MockContextFactory.cs
@@ -14,12 +14,9 @@ namespace PoweredSoft.DynamicQuery.Test.Mock
         public static void TestContextFor(string testName, Action<MockContext> action)
         {
             var options = new DbContextOptionsBuilder<MockContext>()
-                .ConfigureWarnings(warnings => 
-                    warnings.Ignore(RelationalEventId.QueryClientEvaluationWarning)
-                )
                 .UseInMemoryDatabase(databaseName: testName).Options;
 
-            using (var ctx = new MockContext(options))
+            using var ctx = new MockContext(options);
                 action(ctx);
         }
 

--- a/PoweredSoft.DynamicQuery.Test/MockQueryExecutionOptionsInterceptor.cs
+++ b/PoweredSoft.DynamicQuery.Test/MockQueryExecutionOptionsInterceptor.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Query.Internal;
+using PoweredSoft.DynamicQuery.Core;
+using System.Linq;
+
+namespace PoweredSoft.DynamicQuery.Test
+{
+    public partial class GroupInterceptorTests
+    {
+        public class MockQueryExecutionOptionsInterceptor : IQueryExecutionOptionsInterceptor
+        {
+            public IQueryExecutionOptions InterceptQueryExecutionOptions(IQueryable queryable, IQueryExecutionOptions current)
+            {
+                if (queryable.Provider is IAsyncQueryProvider)
+                {
+                    current.GroupByInMemory = true;
+                }
+
+                return current;
+            }
+        }
+    }
+}

--- a/PoweredSoft.DynamicQuery.Test/PoweredSoft.DynamicQuery.Test.csproj
+++ b/PoweredSoft.DynamicQuery.Test/PoweredSoft.DynamicQuery.Test.csproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="28.3.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="PoweredSoft.Data.EntityFrameworkCore" Version="1.1.3" />
+    <PackageReference Include="PoweredSoft.Data.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This should help people deal with regression introduced in EF Core 3.0 with group by not being able to transform into a valid SQL without client evaluations.

By default it would still run as usual, and offer query execution options that would allow the caller to specify he would like the grouping to be executed in memory instead of SQL.

This does help, but must take care of making sure that the objects are well included and null can be added to be checked if the second option is activated.

This could introduce issues, but would allow people to use EF core 3.0 with grouping capabilities in the mean time, not activated by default.
